### PR TITLE
New report: Night battle SS CI for Late Model Torpedo and Submarine Radar

### DIFF
--- a/index.es
+++ b/index.es
@@ -6,6 +6,8 @@ import moment from 'moment'
 
 import { shipDataSelectorFactory, shipEquipDataSelectorFactory } from 'views/utils/selectors'
 
+import { getHpStyle, getCIType } from './utils'
+
 Promise.promisifyAll(request)
 const { SERVER_HOSTNAME } = window
 // const SERVER_HOSTNAME = '127.0.0.1:17027'
@@ -622,63 +624,7 @@ class AACIReporter extends BaseReporter {
   }
 }
 
-const hasAtLeast = num => f => xs => xs.filter(f).length >= num
-const validAll = (...func) => x => func.every(f => f(x))
-const validAny = (...func) => x => func.some(f => f(x))
 
-const equipype2Is = num => equip => _.get(equip, 'api_type.2') === num
-const equipIdIs = num => equip => equip.api_slotitem_id === num
-
-const getHpStyle = (percent) => {
-  if (percent <= 25) {
-    return 'red'
-  } else if (percent <= 50){
-    return 'orange'
-  } else if (percent <= 75){
-    return 'yellow'
-  } else {
-    return 'green'
-  }
-}
-
-// T = Torpedo
-// LMT = Late Model Torpedo
-// R = Radar
-
-const getCIType = (equips) => {
-  if (validAll(
-    hasAtLeast(1)(equipype2Is(51)),
-    hasAtLeast(1)(
-      validAny(
-        equipIdIs(213),
-        equipIdIs(214),
-      )
-    ))(equips))
-    {
-    return 'LMT-R'
-  }
-  if (hasAtLeast(2)(
-    validAny(
-      equipIdIs(213),
-      equipIdIs(214),
-    ))(equips))
-    {
-    return 'LMT-LMT'
-  }
-  if (validAny(
-    hasAtLeast(1)(equipype2Is(51)),
-    hasAtLeast(1)(
-      validAny(
-        equipIdIs(213),
-        equipIdIs(214),
-      )
-  ))(equips))
-    {
-    return 'T-T'
-  }
-
-  return ''
-}
 
 class NightBattleSSCIReporter extends BaseReporter {
   processData = (body, time) => {

--- a/index.es
+++ b/index.es
@@ -624,8 +624,6 @@ class AACIReporter extends BaseReporter {
   }
 }
 
-
-
 class NightBattleSSCIReporter extends BaseReporter {
   processData = (body, time) => {
     const state = window.getStore()
@@ -725,7 +723,7 @@ class NightBattleSSCIReporter extends BaseReporter {
         hitType: cl,
         damage,
         damageTotal: _.sum(damage),
-        time: +new Date(time),
+        time,
       })
     })
   }
@@ -742,7 +740,7 @@ class NightBattleSSCIReporter extends BaseReporter {
 
 let reporters = []
 const handleResponse = (e) => {
-  const {method, path, body, postBody, time = String(new Date())} = e.detail
+  const {method, path, body, postBody, time = Date.now()} = e.detail
   for (const reporter of reporters) {
     try {
       reporter.handle(method, path, body, postBody, time)

--- a/index.es
+++ b/index.es
@@ -3,7 +3,8 @@ import _ from 'lodash'
 import Promise from 'bluebird'
 import request from 'request'
 import moment from 'moment'
-import { get } from 'lodash'
+
+import { shipDataSelectorFactory, shipEquipDataSelectorFactory } from 'views/utils/selectors'
 
 Promise.promisifyAll(request)
 const { SERVER_HOSTNAME } = window
@@ -561,9 +562,6 @@ class AACIReporter extends BaseReporter {
     try {
       const aaci = require('views/utils/aaci')
       this.getShipAACIs = aaci.getShipAACIs
-      const { shipDataSelectorFactory, shipEquipDataSelectorFactory } = require('views/utils/selectors')
-      this.shipDataSelectorFactory = shipDataSelectorFactory
-      this.shipEquipDataSelectorFactory = shipEquipDataSelectorFactory
     }
     catch (err) {
       // console.log(`AACI reporter is disabled.`)
@@ -583,8 +581,8 @@ class AACIReporter extends BaseReporter {
 
       // Available AACI
       const deckData = (deck.api_ship || []).map(shipId => {
-        const [_ship = {}, $ship = {}] = this.shipDataSelectorFactory(shipId)(state) || []
-        const equips = (this.shipEquipDataSelectorFactory(shipId)(state) || [])
+        const [_ship = {}, $ship = {}] = shipDataSelectorFactory(shipId)(state) || []
+        const equips = (shipEquipDataSelectorFactory(shipId)(state) || [])
           .filter(([_equip, $equip, onslot] = []) => !!_equip && !!$equip)
           .map(([_equip, $equip, onslot]) => ({ ...$equip, ..._equip }))
         return [{...$ship, ..._ship}, equips]
@@ -628,7 +626,7 @@ const hasAtLeast = num => f => xs => xs.filter(f).length >= num
 const validAll = (...func) => x => func.every(f => f(x))
 const validAny = (...func) => x => func.some(f => f(x))
 
-const equipype2Is = num => equip => get(equip, 'api_type.2') === num
+const equipype2Is = num => equip => _.get(equip, 'api_type.2') === num
 const equipIdIs = num => equip => equip.api_slotitem_id === num
 
 // T = Torpedo
@@ -671,18 +669,6 @@ const getCIType = (equips) => {
 }
 
 class NightBattleSSCIReporter extends BaseReporter {
-  constructor() {
-    super()
-    try {
-      const { shipDataSelectorFactory, shipEquipDataSelectorFactory } = require('views/utils/selectors')
-      this.shipDataSelectorFactory = shipDataSelectorFactory
-      this.shipEquipDataSelectorFactory = shipEquipDataSelectorFactory
-    }
-    catch (err) {
-      // console.log(`Night Battle SS CI reporter is disabled.`)
-    }
-  }
-
   processData = (body, postBody) => {
     const state = window.getStore()
 
@@ -701,8 +687,8 @@ class NightBattleSSCIReporter extends BaseReporter {
     if (deck == null)  return
 
     const deckData = (deck.api_ship || []).map(shipId => {
-      const [_ship = {}, $ship = {}] = this.shipDataSelectorFactory(shipId)(state) || []
-      const equips = (this.shipEquipDataSelectorFactory(shipId)(state) || [])
+      const [_ship = {}, $ship = {}] = shipDataSelectorFactory(shipId)(state) || []
+      const equips = (shipEquipDataSelectorFactory(shipId)(state) || [])
         .filter(([_equip, $equip, onslot] = []) => !!_equip && !!$equip)
         .map(([_equip, $equip, onslot]) => ({ ...$equip, ..._equip }))
       return [{...$ship, ..._ship}, equips]

--- a/index.es
+++ b/index.es
@@ -761,7 +761,7 @@ class NightBattleSSCIReporter extends BaseReporter {
 
       const [ship, equips] = deckData[i]
 
-      this.report('/api/report/v2/nightbattle_ss_ci', {
+      this.report('/api/report/v2/night_battle_ss_ci', {
         shipId: ship.api_ship_id,
         CI,
         lv: ship.api_lv,
@@ -769,6 +769,7 @@ class NightBattleSSCIReporter extends BaseReporter {
         pos: i,
         status: startStatus,
         items: equips.map(equip => equip.api_slotitem_id),
+        improvement: equips.map(equip => equip.api_level || 0),
         searchLight,
         flare: api_flare_pos[0],
         defenseId,

--- a/index.es
+++ b/index.es
@@ -718,6 +718,7 @@ class NightBattleSSCIReporter extends BaseReporter {
     const {
       api_at_list,
       api_df_list,
+      api_si_list,
       api_sp_list,
       api_cl_list,
       api_damage,
@@ -755,6 +756,7 @@ class NightBattleSSCIReporter extends BaseReporter {
       const damage = api_damage[order]
 
       const sp = api_sp_list[order]
+      const si = api_si_list[order]
       const cl = api_cl_list[order]
 
       const [ship, equips] = deckData[i]
@@ -771,8 +773,9 @@ class NightBattleSSCIReporter extends BaseReporter {
         flare: api_flare_pos[0],
         defenseId,
         defenseTypeId,
-        sp,
-        cl,
+        ciType: sp,
+        display: _.isArray(si) ? si.map(Number) : [Number(si)], // could this be -1?
+        hitType: cl,
         damage,
         damageTotal: _.sum(damage),
         time: +new Date(time),

--- a/index.es
+++ b/index.es
@@ -6,7 +6,7 @@ import moment from 'moment'
 
 import { shipDataSelectorFactory, shipEquipDataSelectorFactory } from 'views/utils/selectors'
 
-import { getHpStyle, getCIType } from './utils'
+import { getHpStyle, getNightBattleSSCIType } from './utils'
 
 Promise.promisifyAll(request)
 const { SERVER_HOSTNAME } = window
@@ -676,7 +676,7 @@ class NightBattleSSCIReporter extends BaseReporter {
     )
 
     SSIndex.forEach((i) => {
-      const CI = getCIType(deckData[i][1])
+      const CI = getNightBattleSSCIType(deckData[i][1])
       if (!CI) {
         return
       }

--- a/index.es
+++ b/index.es
@@ -684,12 +684,8 @@ class NightBattleSSCIReporter extends BaseReporter {
   processData = (body, time) => {
     const state = window.getStore()
 
-    // 15: N -> O
-    // 19: M -> O
-    // 20: K -> O
-    if (state.sortie.sortieMapId !== 54 &&
-      ![15, 19, 20].includes(state.sortie.currentNode)
-    ) {
+    // normal map only
+    if (state.sortie.sortieMapId > 100) {
       return
     }
 

--- a/index.es
+++ b/index.es
@@ -655,7 +655,7 @@ const getCIType = (equips) => {
       )
     ))(equips))
     {
-    return 'LMTR'
+    return 'LMT-R'
   }
   if (hasAtLeast(2)(
     validAny(
@@ -663,7 +663,7 @@ const getCIType = (equips) => {
       equipIdIs(214),
     ))(equips))
     {
-    return 'LMTLMT'
+    return 'LMT-LMT'
   }
   if (validAny(
     hasAtLeast(1)(equipype2Is(51)),
@@ -674,7 +674,7 @@ const getCIType = (equips) => {
       )
   ))(equips))
     {
-    return 'TT'
+    return 'T-T'
   }
 
   return ''
@@ -736,8 +736,8 @@ class NightBattleSSCIReporter extends BaseReporter {
         return
       }
 
-      const startStatus = getHpStyle(api_nowhps[i + 1] / api_maxhps[i + 1])
-      const endStatus = getHpStyle(endHps[i] / api_maxhps[i + 1])
+      const startStatus = getHpStyle(api_nowhps[i + 1] * 100 / api_maxhps[i + 1])
+      const endStatus = getHpStyle(endHps[i] * 100 / api_maxhps[i + 1])
 
       if (startStatus !== endStatus || startStatus === 'red') {
         return
@@ -749,7 +749,7 @@ class NightBattleSSCIReporter extends BaseReporter {
       }
 
       const defense = api_df_list[order][0]
-      const defenseId = api_ship_ke[defense]
+      const defenseId = api_ship_ke[defense - 6]
       const defenseTypeId = _.get(state, `const.$ships.${defenseId}.api_stype`)
 
       const damage = api_damage[order]
@@ -759,8 +759,9 @@ class NightBattleSSCIReporter extends BaseReporter {
 
       const [ship, equips] = deckData[i]
 
-      console.log({
+      this.report('/api/report/v2/nightbattle_ss_ci', {
         shipId: ship.api_ship_id,
+        CI,
         lv: ship.api_lv,
         rawLuck: ship.api_luck[0] + ship.api_kyouka[4],
         pos: i,
@@ -773,9 +774,9 @@ class NightBattleSSCIReporter extends BaseReporter {
         sp,
         cl,
         damage,
+        damageTotal: _.sum(damage),
         time: +new Date(time),
       })
-
     })
   }
 
@@ -813,7 +814,7 @@ export const pluginDidLoad = (e) => {
     new NightContactReportor(),
     new RemodelRecipeReporter(),
     new AACIReporter(),
-    new NightBattleSSCIReporter()
+    new NightBattleSSCIReporter(),
   ]
   window.addEventListener('game.response', handleResponse)
 }

--- a/utils.es
+++ b/utils.es
@@ -1,0 +1,59 @@
+import _ from 'lodash'
+
+const hasAtLeast = num => f => xs => xs.filter(f).length >= num
+const validAll = (...func) => x => func.every(f => f(x))
+const validAny = (...func) => x => func.some(f => f(x))
+
+const equipype2Is = num => equip => _.get(equip, 'api_type.2') === num
+const equipIdIs = num => equip => equip.api_slotitem_id === num
+
+export const getHpStyle = (percent) => {
+  if (percent <= 25) {
+    return 'red'
+  } else if (percent <= 50){
+    return 'orange'
+  } else if (percent <= 75){
+    return 'yellow'
+  } else {
+    return 'green'
+  }
+}
+
+// T = Torpedo
+// LMT = Late Model Torpedo
+// R = Radar
+
+export const getCIType = (equips) => {
+  if (validAll(
+    hasAtLeast(1)(equipype2Is(51)),
+    hasAtLeast(1)(
+      validAny(
+        equipIdIs(213),
+        equipIdIs(214),
+      )
+    ))(equips))
+    {
+    return 'LMT-R'
+  }
+  if (hasAtLeast(2)(
+    validAny(
+      equipIdIs(213),
+      equipIdIs(214),
+    ))(equips))
+    {
+    return 'LMT-LMT'
+  }
+  if (validAny(
+    hasAtLeast(1)(equipype2Is(51)),
+    hasAtLeast(1)(
+      validAny(
+        equipIdIs(213),
+        equipIdIs(214),
+      )
+  ))(equips))
+    {
+    return 'T-T'
+  }
+
+  return ''
+}

--- a/utils.es
+++ b/utils.es
@@ -23,7 +23,7 @@ export const getHpStyle = (percent) => {
 // LMT = Late Model Torpedo
 // R = Radar
 
-export const getCIType = (equips) => {
+export const getNightBattleSSCIType = (equips) => {
   if (validAll(
     hasAtLeast(1)(equipype2Is(51)),
     hasAtLeast(1)(


### PR DESCRIPTION
We'll have:
+ `shipId`,
+ `CI`: the ci type we guess,
+ `lv`: ship level,
+ `rawLuck`: luck without equipment,
+ `pos`: ship in fleet position, starts from 0,
+ `status`: one of [green, yellow, orange, red],
+ `items`: item ids,
+ `improvement`,
+ `searchLight`: if a ship equips a search light and its hp > 1 at the begining of night battle,
+ `flare`: star shell position, starts from 1,
+ `defenseId`: enemy ship being attacked,
+ `defenseTypeId`: its type,
+ `ciType`: API CI Type,
+ `display`: items displayed in game,
+ `hitType`: hit type,
+ `damage`: damages,
+ `damageTotal`: sum of damages,
+ `time`: the packet timestamp in poi