### PR TITLE
Player tracking via hash, owned ship counters for drops, event rewards

### DIFF
--- a/reporters/drop-ship.es
+++ b/reporters/drop-ship.es
@@ -88,7 +88,10 @@ export default class DropShipReporter extends BaseReporter {
       drop.shipCounts = drop.shipId !== -1 ? countOwnedShips(drop.shipId) : []
       drop.teitokuLv = _teitokuLv
       drop.teitokuId = teitokuId
-      this.report('/api/report/v2/drop_ship', drop)
+      // Report enemy pattern and drops
+      this.report('/api/report/v2/drop_ship', drop).then(() => {
+        this.drop = null
+      })
       // Report pass event
       if (body.api_get_eventitem != null) {
         this.report('/api/report/v2/pass_event', {

--- a/reporters/drop-ship.es
+++ b/reporters/drop-ship.es
@@ -1,5 +1,5 @@
 import BaseReporter from './base'
-import { getTeitokuHash } from './utils'
+import { countOwnedShips, getTeitokuHash } from './utils'
 
 export default class DropShipReporter extends BaseReporter {
   constructor() {
@@ -48,6 +48,7 @@ export default class DropShipReporter extends BaseReporter {
         rank  : null,
         shipId: null,
         itemId: null,
+        shipCounts: null,
         teitokuLv: null,
         teitokuId: null,
       }
@@ -84,6 +85,7 @@ export default class DropShipReporter extends BaseReporter {
       drop.baseExp = body.api_get_base_exp
       drop.shipId = (body.api_get_ship || {}).api_ship_id || -1
       drop.itemId = (body.api_get_useitem || {}).api_useitem_id || -1
+      drop.shipCounts = drop.shipId !== -1 ? countOwnedShips(drop.shipId) : []
       drop.teitokuLv = _teitokuLv
       drop.teitokuId = teitokuId
       this.report('/api/report/v2/drop_ship', drop)

--- a/reporters/drop-ship.es
+++ b/reporters/drop-ship.es
@@ -101,6 +101,13 @@ export default class DropShipReporter extends BaseReporter {
           teitokuLv: _teitokuLv,
           mapId: drop.mapId,
           mapLv: drop.mapLv,
+          rewards: !Array.isArray(body.api_get_eventitem)
+            ? null
+            : body.api_get_eventitem.map(e => ({
+              rewardType: e.api_type,
+              rewardId: e.api_id,
+              rewardCount: e.api_value,
+            })),
         })
       }
     } break

--- a/reporters/drop-ship.es
+++ b/reporters/drop-ship.es
@@ -1,4 +1,5 @@
 import BaseReporter from './base'
+import { getTeitokuHash } from './utils'
 
 export default class DropShipReporter extends BaseReporter {
   constructor() {
@@ -9,7 +10,8 @@ export default class DropShipReporter extends BaseReporter {
   }
   handle(method, path, body, postBody) {
     const { mapLv } = this
-    const { _teitokuId, _teitokuLv, _nickName } = window
+    const { _teitokuLv } = window
+    const teitokuId = getTeitokuHash()
     switch(path) {
     case '/kcsapi/api_get_member/mapinfo': {
       for (const map of body.api_map_info) {
@@ -24,7 +26,7 @@ export default class DropShipReporter extends BaseReporter {
       mapLv[mapareaId] = parseInt(postBody.api_rank)
       // Report select map difficulty
       this.report("/api/report/v2/select_rank", {
-        teitokuId: _teitokuId,
+        teitokuId,
         teitokuLv: _teitokuLv,
         mapareaId: mapareaId,
         rank: rank,
@@ -47,6 +49,7 @@ export default class DropShipReporter extends BaseReporter {
         shipId: null,
         itemId: null,
         teitokuLv: null,
+        teitokuId: null,
       }
       drop.mapId  = body.api_maparea_id * 10 + body.api_mapinfo_no
       drop.cellId = body.api_no
@@ -82,13 +85,13 @@ export default class DropShipReporter extends BaseReporter {
       drop.shipId = (body.api_get_ship || {}).api_ship_id || -1
       drop.itemId = (body.api_get_useitem || {}).api_useitem_id || -1
       drop.teitokuLv = _teitokuLv
+      drop.teitokuId = teitokuId
       this.report('/api/report/v2/drop_ship', drop)
       // Report pass event
       if (body.api_get_eventitem != null) {
         this.report('/api/report/v2/pass_event', {
-          teitokuId: _teitokuId,
+          teitokuId,
           teitokuLv: _teitokuLv,
-          teitoku: _nickName,
           mapId: drop.mapId,
           mapLv: drop.mapLv,
         })

--- a/reporters/drop-ship.es
+++ b/reporters/drop-ship.es
@@ -1,5 +1,5 @@
 import BaseReporter from './base'
-import { countOwnedShips, getTeitokuHash } from './utils'
+import { getOwnedShipIds, countOwnedShipForms, getTeitokuHash } from './utils'
 
 export default class DropShipReporter extends BaseReporter {
   constructor() {
@@ -7,6 +7,7 @@ export default class DropShipReporter extends BaseReporter {
 
     this.mapLv = []
     this.drop = null
+    this.ownedShipIds = null
   }
   handle(method, path, body, postBody) {
     const { mapLv } = this
@@ -25,7 +26,7 @@ export default class DropShipReporter extends BaseReporter {
       const rank = parseInt(postBody.api_rank)
       mapLv[mapareaId] = parseInt(postBody.api_rank)
       // Report select map difficulty
-      this.report("/api/report/v2/select_rank", {
+      this.report('/api/report/v2/select_rank', {
         teitokuId,
         teitokuLv: _teitokuLv,
         mapareaId: mapareaId,
@@ -57,6 +58,7 @@ export default class DropShipReporter extends BaseReporter {
       drop.isBoss = body.api_event_id == 5
       drop.mapLv  = mapLv[drop.mapId]
       this.drop = drop
+      this.ownedShipIds = getOwnedShipIds()
     } break
     case '/kcsapi/api_req_sortie/battle':
     case '/kcsapi/api_req_sortie/airbattle':
@@ -85,7 +87,7 @@ export default class DropShipReporter extends BaseReporter {
       drop.baseExp = body.api_get_base_exp
       drop.shipId = (body.api_get_ship || {}).api_ship_id || -1
       drop.itemId = (body.api_get_useitem || {}).api_useitem_id || -1
-      drop.shipCounts = drop.shipId !== -1 ? countOwnedShips(drop.shipId) : []
+      drop.shipCounts = drop.shipId !== -1 ? countOwnedShipForms(this.ownedShipIds, drop.shipId) : []
       drop.teitokuLv = _teitokuLv
       drop.teitokuId = teitokuId
       // Report enemy pattern and drops

--- a/reporters/utils.es
+++ b/reporters/utils.es
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import _ from 'lodash'
 
 const hasAtLeast = num => f => xs => xs.filter(f).length >= num
@@ -92,4 +93,19 @@ export const getNightBattleDDCIType = (equips) => {
   }
 
   return ''
+}
+
+let teitokuId = window._teitokuId
+let teitokuHash = null
+
+export const getTeitokuHash = () => {
+  const { _teitokuId, _nickName, _nickNameId } = window
+  if ((teitokuId !== _teitokuId || !teitokuHash)
+      && _teitokuId !== -1 && _nickName && _nickNameId !== -1) {
+    teitokuId = _teitokuId
+    teitokuHash = createHash('sha1')
+      .update(`${_teitokuId}_${_nickName}_${_nickNameId}`)
+      .digest('base64')
+  }
+  return teitokuHash
 }

--- a/reporters/utils.es
+++ b/reporters/utils.es
@@ -109,3 +109,27 @@ export const getTeitokuHash = () => {
   }
   return teitokuHash
 }
+
+/**
+ * Count all owned remodels of a given ship.
+ *
+ * E.g., having 2 Taigei and 1 Ryuuhou Kai will return [2, 0, 1].
+ *
+ * Returns [] if none of the forms are owned.
+ */
+export const countOwnedShips = (baseId) => {
+  const $ships = window.$ships || {}
+  const _ships = window._ships || {}
+  let current = $ships[baseId]
+  let nextId = +(current.api_aftershipid || 0)
+  let ids = [baseId]
+  let cutoff = 10
+  while (!ids.includes(nextId) && nextId > 0 && cutoff > 0) {
+    ids = [...ids, nextId]
+    current = $ships[nextId] || {}
+    nextId = +(current.api_aftershipid || 0)
+    --cutoff
+  }
+  const counts = ids.map(api_ship_id => _.filter(_ships, { api_ship_id }).length)
+  return _.dropRightWhile(counts, e => !e)
+}

--- a/reporters/utils.es
+++ b/reporters/utils.es
@@ -110,6 +110,8 @@ export const getTeitokuHash = () => {
   return teitokuHash
 }
 
+export const getOwnedShipIds = () => _.map(window._ships, e => e.api_ship_id)
+
 /**
  * Count all owned remodels of a given ship.
  *
@@ -117,9 +119,8 @@ export const getTeitokuHash = () => {
  *
  * Returns [] if none of the forms are owned.
  */
-export const countOwnedShips = (baseId) => {
-  const $ships = window.$ships || {}
-  const _ships = window._ships || {}
+export const countOwnedShipForms = (ownedShipsIds, baseId) => {
+  const $ships = window.$ships
   let current = $ships[baseId]
   let nextId = +(current.api_aftershipid || 0)
   let ids = [baseId]
@@ -130,6 +131,6 @@ export const countOwnedShips = (baseId) => {
     nextId = +(current.api_aftershipid || 0)
     --cutoff
   }
-  const counts = ids.map(api_ship_id => _.filter(_ships, { api_ship_id }).length)
+  const counts = ids.map(api_ship_id => ownedShipsIds.filter(id => id === api_ship_id).length)
   return _.dropRightWhile(counts, e => !e)
 }


### PR DESCRIPTION
- add new hash field in drop_ship
- use the hash instead of game ID in select_rank and pass_event
- don't send game name in pass_event
---
Was agreed in https://github.com/poooi/poi-server/issues/36 that a hash should be used instead of _teitokuId for tracking. SHA1 hash in base64 encoding will add extra 28 bytes to each record in drop collection (for MD5 would be 24).

Also, replaced _teitokuId with that hash for two other collections and removed name, since the hash can be used to differentiate players.