### PR TITLE
Update getNightBattleDDCIType for new CI and equipment

### DIFF
--- a/reporters/utils.es
+++ b/reporters/utils.es
@@ -53,6 +53,8 @@ const houmAboveOrEqual = num => equip => equip.api_houm >= num
 
 // G_T_R = Gun Torpedo Radar
 // T_R_P = Torpedo Radar Personnel
+// T_P_T Torpedo Personnel Torpedo
+// T_P_D Torpedo Personnel Drum
 export const getNightBattleDDCIType = equips => {
   if (
     validAll(
@@ -72,6 +74,20 @@ export const getNightBattleDDCIType = equips => {
     )(equips)
   ) {
     return 'DD_T_R_P'
+  }
+
+  if (validAll(hasAtLeast(2)(equipType2Is(5)), hasAtLeast(1)(equipIdIs(412)))(equips)) {
+    return 'DD_T_P_T'
+  }
+
+  if (
+    validAll(
+      hasAtLeast(1)(equipType2Is(5)),
+      hasAtLeast(1)(equipIdIs(412)),
+      hasAtLeast(1)(equipType2Is(30)),
+    )(equips)
+  ) {
+    return 'DD_T_P_D'
   }
 
   return ''

--- a/reporters/utils.es
+++ b/reporters/utils.es
@@ -69,7 +69,7 @@ export const getNightBattleDDCIType = equips => {
   if (
     validAll(
       hasAtLeast(1)(equipType2Is(5)),
-      hasAtLeast(1)(equipIdIs(129)),
+      hasAtLeast(1)(equipType2Is(39)),
       hasAtLeast(1)(validAll(validAny(equipType2Is(12), equipType2Is(13)), houmAboveOrEqual(3))),
     )(equips)
   ) {


### PR DESCRIPTION
Tests done
Check that TPT setup works
```
{"data":{"shipId":566,"type":"DD","CI":"DD_T_P_T","lv":136,"rawLuck":26,"pos":0,"status":"yellow","items":[58,58,101,412],"improvement":[6,6,0,4],"searchLight":false,"flare":0,"defenseId":1501,"defenseTypeId":2,"ciType":13,"display":[58,58,412],"hitType":[1,1],"damage":[294,294],"damageTotal":588,"time":1622341680812}}
```
Check that TPT logs other CI
```
{"data":{"shipId":566,"type":"DD","CI":"DD_T_P_T","lv":136,"rawLuck":26,"pos":0,"status":"yellow","items":[58,58,101,412],"improvement":[6,6,0,4],"searchLight":false,"flare":-1,"defenseId":1501,"defenseTypeId":2,"ciType":3,"display":[58,58],"hitType":[1,1],"damage":[293,292],"damageTotal":585,"time":1622341814102}}
```
Check that TPD setup works
```
{"data":{"shipId":566,"type":"DD","CI":"DD_T_P_D","lv":136,"rawLuck":26,"pos":0,"status":"yellow","items":[58,75,101,412],"improvement":[6,0,0,4],"searchLight":false,"flare":0,"defenseId":1502,"defenseTypeId":2,"ciType":0,"display":[58],"hitType":[1],"damage":[177],"damageTotal":177,"time":1622341919020}}
```
Check that new personnel equipment works with existing DDCI
```
{"data":{"shipId":566,"type":"DD","CI":"DD_T_R_P","lv":136,"rawLuck":26,"pos":0,"status":"yellow","items":[58,307,101,412],"improvement":[6,0,0,4],"searchLight":false,"flare":-1,"defenseId":1505,"defenseTypeId":3,"ciType":8,"display":[58,307,412],"hitType":[1,-1,-1],"damage":[211,-1,-1],"damageTotal":211,"time":1622346462286}}
```

As an additional request, would it be possible to add more cases for `night-battle-ci`?
It would be nice to get more data by removing the normal map filter (could add a `sortieMapId` field to compensate) and also adding more paths such as `api_req_battle_midnight/sp_midnight` (battle starts from night, for maps like 5-3 where it would be easier to collect data)